### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/sferg0325/faf8300b-43ed-4573-a61d-69e23d985e4f/8b2aae5d-ead6-4daf-aa93-0bfacf94f866/_apis/work/boardbadge/d22fd271-f0d3-48b9-8bcb-e7f2d2ed5528)](https://dev.azure.com/sferg0325/faf8300b-43ed-4573-a61d-69e23d985e4f/_boards/board/t/8b2aae5d-ead6-4daf-aa93-0bfacf94f866/Microsoft.RequirementCategory)
 # testing
 AB#1
 d


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/sferg0325/faf8300b-43ed-4573-a61d-69e23d985e4f/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.